### PR TITLE
fix: Defender recieves loss penalty

### DIFF
--- a/marlon/baseline_models/a2c/train.py
+++ b/marlon/baseline_models/a2c/train.py
@@ -6,8 +6,9 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 2000
 LEARN_TIMESTEPS = 10_000
 LEARN_EPISODES = 1000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ENABLE_ACTION_PENALTY = True
+ATTACKER_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
+ATTACKER_SAVE_PATH = 'a2c.zip'
 
 def train(evaluate_after=False):
     universe = MultiAgentUniverse.build(
@@ -16,7 +17,7 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_enable_action_penalty=ENABLE_ACTION_PENALTY
+        attacker_invalid_action_reward=ATTACKER_ACTION_REWARD
     )
 
     universe.learn(
@@ -25,7 +26,7 @@ def train(evaluate_after=False):
     )
 
     universe.save(
-        attacker_filepath='a2c.zip'
+        attacker_filepath=ATTACKER_SAVE_PATH
     )
 
     if evaluate_after:

--- a/marlon/baseline_models/env_wrappers/environment_event_source.py
+++ b/marlon/baseline_models/env_wrappers/environment_event_source.py
@@ -6,7 +6,7 @@ class IEnvironmentObserver:
     Interface for classes that want to subscribe to environment events.
     """
     @abstractmethod
-    def on_reset(self):
+    def on_reset(self, last_reward):
         """ Notified when environment is reset. """
         raise NotImplementedError
 
@@ -17,7 +17,7 @@ class EnvironmentEventSource:
     def add_observer(self, observer: IEnvironmentObserver):
         self.observers.append(observer)
 
-    def notify_reset(self):
+    def notify_reset(self, last_reward):
         # Notify all observers that a reset was called.
         for observer in self.observers:
-            observer.on_reset()
+            observer.on_reset(last_reward)

--- a/marlon/baseline_models/multiagent/baseline_marlon_agent.py
+++ b/marlon/baseline_models/multiagent/baseline_marlon_agent.py
@@ -27,6 +27,17 @@ class BaselineAgentBuilder(AgentBuilder):
         model = self.alg_type(self.policy, Monitor(wrapper), verbose=1)
         return BaselineMarlonAgent(model, wrapper)
 
+class LoadFileBaselineAgentBuilder(AgentBuilder):
+    def __init__(self, alg_type: Type, file_path: str):
+        assert issubclass(alg_type, OnPolicyAlgorithm), "Algorithm type must inherit OnPolicyAlgorithm."
+
+        self.alg_type = alg_type
+        self.model = self.alg_type.load(file_path)
+
+    def build(self, wrapper: GymEnv) -> MarlonAgent:
+        self.model.env = Monitor(wrapper)
+        return BaselineMarlonAgent(self.model, wrapper)
+
 class BaselineMarlonAgent(MarlonAgent):
     def __init__(self, baseline_model: OnPolicyAlgorithm, wrapper):
         self.baseline_model: OnPolicyAlgorithm = baseline_model

--- a/marlon/baseline_models/multiagent/multiagent_universe.py
+++ b/marlon/baseline_models/multiagent/multiagent_universe.py
@@ -24,11 +24,12 @@ class MultiAgentUniverse:
     @classmethod
     def build(cls,
         attacker_builder: AgentBuilder,
-        attacker_enable_action_penalty = True,
+        attacker_invalid_action_reward = -1,
         defender_builder: Optional[AgentBuilder] = None,
-        defender_enable_action_penalty = True,
+        defender_invalid_action_reward = -1,
         env_id: str = "CyberBattleToyCtf-v0",
-        max_timesteps: int = 2000):
+        max_timesteps: int = 2000,
+        attacker_loss_reward: float = -5000.0):
 
         if defender_builder:
             cyber_env = gym.make(
@@ -43,7 +44,8 @@ class MultiAgentUniverse:
             cyber_env=cyber_env,
             event_source=event_source,
             max_timesteps=max_timesteps,
-            enable_action_penalty=attacker_enable_action_penalty
+            invalid_action_reward=attacker_invalid_action_reward,
+            loss_reward=attacker_loss_reward
         )
         attacker_agent = attacker_builder.build(attacker_wrapper)
 
@@ -54,7 +56,7 @@ class MultiAgentUniverse:
                 event_source=event_source,
                 attacker_reward_store=attacker_wrapper,
                 max_timesteps=max_timesteps,
-                enable_action_penalty=defender_enable_action_penalty,
+                enable_action_penalty=defender_invalid_action_reward,
                 defender=True
             )
             defender_agent = defender_builder.build(defender_wrapper)
@@ -138,10 +140,3 @@ class MultiAgentUniverse:
             self.defender_agent is not None:
 
             self.defender_agent.save(defender_filepath)
-
-    def load(self,
-        attacker_filepath: str,
-        defender_filepath: Optional[str] = None):
-
-        # TODO
-        raise NotImplementedError

--- a/marlon/baseline_models/ppo/eval_defender.py
+++ b/marlon/baseline_models/ppo/eval_defender.py
@@ -1,49 +1,25 @@
-import numpy as np
+from stable_baselines3 import PPO
+from marlon.baseline_models.multiagent.baseline_marlon_agent import LoadFileBaselineAgentBuilder
+from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniverse
+from marlon.baseline_models.multiagent.random_marlon_agent import RandomAgentBuilder
+from marlon.baseline_models.ppo.train_defender import DEFENDER_SAVE_PATH
 
-import gym
-from stable_baselines3.common.monitor import Monitor
-from stable_baselines3.ppo.ppo import PPO
-from stable_baselines3.common.evaluation import evaluate_policy
-from marlon.baseline_models.env_wrappers.attack_wrapper import AttackerEnvWrapper
+EVALUATE_EPISODES = 5
 
-from marlon.baseline_models.env_wrappers.defend_wrapper import DefenderEnvWrapper
-from marlon.baseline_models.env_wrappers.environment_event_source import EnvironmentEventSource
-from marlon.defender_agents.defender import PrototypeLearningDefender
-
-def evaluate(max_timesteps):
-    env_id = "CyberBattleToyCtf-v0"
-    cyber_env = gym.make(
-        env_id,
-        defender_agent=PrototypeLearningDefender())
-
-    wrapper_coordinator = EnvironmentEventSource()
-    attacker_wrapper = AttackerEnvWrapper(
-        cyber_env=cyber_env,
-        event_source=wrapper_coordinator,
-        max_timesteps=max_timesteps,
-        enable_action_penalty=False
+def evaluate():
+    universe = MultiAgentUniverse.build(
+        env_id='CyberBattleToyCtf-v0',
+        attacker_builder=RandomAgentBuilder(),
+        defender_builder=LoadFileBaselineAgentBuilder(
+            alg_type=PPO,
+            file_path=DEFENDER_SAVE_PATH
+        ),
+        attacker_invalid_action_reward=0
     )
 
-    defender_wrapper = DefenderEnvWrapper(
-        cyber_env=cyber_env,
-        attacker_reward_store=attacker_wrapper,
-        event_source=wrapper_coordinator,
-        max_timesteps=max_timesteps,
-        enable_action_penalty=False
+    universe.evaluate(
+        n_episodes=EVALUATE_EPISODES
     )
-
-    defender_model = PPO.load('ppo_defender.zip')
-
-    mean_reward, std_reward = evaluate_policy(defender_model, Monitor(defender_wrapper), n_eval_episodes=10)
-
-    obs = defender_wrapper.reset()
-    for _ in range(2000):
-        action, _states = defender_model.predict(obs)
-        obs, _reward, _done, _info = defender_wrapper.step(action)
-
-    tot_rewards = np.sum(defender_wrapper.rewards)
-    print('tot reward', tot_rewards, 'mean reward', mean_reward, 'std reward', std_reward)
-    print('valid actions', defender_wrapper.valid_action_count, 'invalid actions', defender_wrapper.invalid_action_count)
 
 if __name__ == "__main__":
-    evaluate(2000)
+    evaluate()

--- a/marlon/baseline_models/ppo/eval_marl.py
+++ b/marlon/baseline_models/ppo/eval_marl.py
@@ -1,7 +1,8 @@
 from stable_baselines3 import PPO
 from marlon.baseline_models.multiagent.baseline_marlon_agent import LoadFileBaselineAgentBuilder
 from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniverse
-from marlon.baseline_models.ppo.train import ATTACKER_SAVE_PATH
+from marlon.baseline_models.ppo.train_marl import ATTACKER_SAVE_PATH
+from marlon.baseline_models.ppo.train_marl import DEFENDER_SAVE_PATH
 
 EVALUATE_EPISODES = 5
 
@@ -12,7 +13,12 @@ def evaluate():
             alg_type=PPO,
             file_path=ATTACKER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0
+        defender_builder=LoadFileBaselineAgentBuilder(
+            alg_type=PPO,
+            file_path=DEFENDER_SAVE_PATH
+        ),
+        attacker_invalid_action_reward=0,
+        defender_invalid_action_reward=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/ppo/train.py
+++ b/marlon/baseline_models/ppo/train.py
@@ -6,8 +6,9 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 2000
 LEARN_TIMESTEPS = 10_000
 LEARN_EPISODES = 1000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ENABLE_ACTION_PENALTY = True
+ATTACKER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
+ATTACKER_SAVE_PATH = 'ppo.zip'
 
 def train(evaluate_after=False):
     universe = MultiAgentUniverse.build(
@@ -16,7 +17,7 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_enable_action_penalty=ENABLE_ACTION_PENALTY
+        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD
     )
 
     universe.learn(
@@ -25,7 +26,7 @@ def train(evaluate_after=False):
     )
 
     universe.save(
-        attacker_filepath='ppo.zip'
+        attacker_filepath=ATTACKER_SAVE_PATH
     )
 
     if evaluate_after:

--- a/marlon/baseline_models/ppo/train_defender.py
+++ b/marlon/baseline_models/ppo/train_defender.py
@@ -7,8 +7,10 @@ from marlon.baseline_models.multiagent.random_marlon_agent import RandomAgentBui
 ENV_MAX_TIMESTEPS = 2000
 LEARN_TIMESTEPS = 10_0000
 LEARN_EPISODES = 1000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ENABLE_ACTION_PENALTY = True
+ATTACKER_INVALID_ACTION_REWARD = -1
+DEFENDER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
+DEFENDER_SAVE_PATH = 'ppo_defender.zip'
 
 def train(evaluate_after=False):
     universe = MultiAgentUniverse.build(
@@ -18,8 +20,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_enable_action_penalty=ENABLE_ACTION_PENALTY,
-        defender_enable_action_penalty=ENABLE_ACTION_PENALTY
+        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(
@@ -27,7 +29,7 @@ def train(evaluate_after=False):
         n_eval_episodes=LEARN_EPISODES
     )
     universe.save(
-        defender_filepath='ppo_defender.zip'
+        defender_filepath=DEFENDER_SAVE_PATH
     )
 
     if evaluate_after:

--- a/marlon/baseline_models/ppo/train_marl.py
+++ b/marlon/baseline_models/ppo/train_marl.py
@@ -6,8 +6,11 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 2000
 LEARN_TIMESTEPS = 10_000
 LEARN_EPISODES = 1000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ENABLE_ACTION_PENALTY = True
+ATTACKER_INVALID_ACTION_REWARD = -1
+DEFENDER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
+ATTACKER_SAVE_PATH = 'ppo_marl_attacker.zip'
+DEFENDER_SAVE_PATH = 'ppo_marl_defender.zip'
 
 def train(evaluate_after=False):
     universe = MultiAgentUniverse.build(
@@ -20,8 +23,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_enable_action_penalty=ENABLE_ACTION_PENALTY,
-        defender_enable_action_penalty=ENABLE_ACTION_PENALTY
+        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(
@@ -30,8 +33,8 @@ def train(evaluate_after=False):
     )
 
     universe.save(
-        attacker_filepath='ppo_marl_attacker.zip',
-        defender_filepath='ppo_marl_defender.zip'
+        attacker_filepath=ATTACKER_SAVE_PATH,
+        defender_filepath=DEFENDER_SAVE_PATH
     )
 
     if evaluate_after:

--- a/marlon/simulate.py
+++ b/marlon/simulate.py
@@ -35,7 +35,7 @@ def run_baselines_simulation(model, iteration_count):
     # Load the Gym environment
     gymid = "CyberBattleToyCtf-v0"
     gym_env = gym.make(gymid)
-    gym_env = AttackerEnvWrapper(gym_env, enable_action_penalty=False)
+    gym_env = AttackerEnvWrapper(gym_env, invalid_action_reward=False)
 
     obs = gym_env.reset()
 

--- a/marlon/simulate.py
+++ b/marlon/simulate.py
@@ -23,9 +23,9 @@ def generate_graph_json(cyberbattle_env: CyberBattleEnv, iteration, current_scor
 
 def run_simulation(iteration_count, agent_file):
     if agent_file.endswith('.zip'):
-        if agent_file == 'ppo.zip':
+        if 'ppo' in agent_file:
             model = PPO.load(agent_file)
-        elif agent_file == 'a2c.zip':
+        elif 'a2c' in agent_file:
             model = A2C.load(agent_file)
         return run_baselines_simulation(model, iteration_count)
     else:


### PR DESCRIPTION
If the attacker were to finish before the defender at reset itself, this ensures the defender receives the attacker's final reward before reset when it takes its turn.

Of course, we know the attacker can never end the game in our default environment, but the idea is still good I guess.