### PR TITLE
feat: Evaluate script saves CSV results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pkl
 *.zip
+*.csv

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,4 +1,5 @@
 
+from time import sleep
 from typing import Dict
 import csv
 from stable_baselines3 import A2C, PPO
@@ -25,13 +26,23 @@ def write_csv(results: Dict[str, Dict[str, EvalutionStats]]):
                 stats.mean_defender_valid, stats.std_defender_valid,
                 stats.mean_defender_invalid, stats.std_defender_invalid,])
 
-    with open('eval_results.csv', 'w', encoding='UTF-8') as csvfile:
-        csvwriter = csv.writer(csvfile)
+    notified_wait = False
+    while True:
+        try:
+            with open('eval_results.csv', 'w', encoding='UTF-8') as csvfile:
+                csvwriter = csv.writer(csvfile)
 
-        csvwriter.writerow(['', '', 'Episode Length', '', 'Attacker Score', '', 'Attacker Valid Actions', '', 'Attacker Invalid Actions', '', 'Defender Score', '', 'Defender Valid Actions', '', 'Defender Invalid Actions', ''])
-        csvwriter.writerow(['Attacker', 'Defender', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', ])
+                csvwriter.writerow(['', '', 'Episode Length', '', 'Attacker Score', '', 'Attacker Valid Actions', '', 'Attacker Invalid Actions', '', 'Defender Score', '', 'Defender Valid Actions', '', 'Defender Invalid Actions', ''])
+                csvwriter.writerow(['Attacker', 'Defender', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', 'Mean', 'Std. Dev', ])
 
-        csvwriter.writerows(rows)
+                csvwriter.writerows(rows)
+                break
+        except PermissionError:
+            if not notified_wait:
+                print('Waiting for access to file')
+                notified_wait = True
+
+            sleep(10)
 
     print('Done!')
 
@@ -43,6 +54,7 @@ def main():
         'deepq': QCompatibilityAgentBuilder('deepq.pkl'),
         'ppo': LoadFileBaselineAgentBuilder(PPO, 'ppo.zip'),
         'ppo_marl': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_attacker.zip'),
+        'ppo_marl_no_reset': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_no_reset.zip'),
         'a2c': LoadFileBaselineAgentBuilder(A2C, 'a2c.zip'),
         'a2c_marl': LoadFileBaselineAgentBuilder(A2C, 'a2c_marl_attacker.zip'),
     }
@@ -52,6 +64,7 @@ def main():
         'random': RandomAgentBuilder(),
         'ppo': LoadFileBaselineAgentBuilder(PPO, 'ppo_defender.zip'),
         'ppo_marl': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_defender.zip'),
+        'ppo_marl_no_reset': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_defender_no_reset.zip'),
         'a2c': LoadFileBaselineAgentBuilder(A2C, 'a2c_defender.zip'),
         'a2c_marl': LoadFileBaselineAgentBuilder(A2C, 'a2c_marl_defender.zip'),
     }

--- a/marlon/baseline_models/a2c/eval.py
+++ b/marlon/baseline_models/a2c/eval.py
@@ -12,7 +12,7 @@ def evaluate():
             alg_type=A2C,
             file_path=ATTACKER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/a2c/eval_defender.py
+++ b/marlon/baseline_models/a2c/eval_defender.py
@@ -14,7 +14,7 @@ def evaluate():
             alg_type=A2C,
             file_path=DEFENDER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/a2c/eval_marl.py
+++ b/marlon/baseline_models/a2c/eval_marl.py
@@ -17,8 +17,8 @@ def evaluate():
             alg_type=A2C,
             file_path=DEFENDER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0,
-        defender_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0,
+        defender_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/a2c/train.py
+++ b/marlon/baseline_models/a2c/train.py
@@ -6,7 +6,8 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 1500
 LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ATTACKER_INVALID_ACTION_REWARD = -1
+ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
+ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'a2c.zip'
 
@@ -17,7 +18,8 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
+        attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER
     )
 
     universe.learn(

--- a/marlon/baseline_models/a2c/train_defender.py
+++ b/marlon/baseline_models/a2c/train_defender.py
@@ -20,8 +20,8 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
-        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(

--- a/marlon/baseline_models/a2c/train_defender.py
+++ b/marlon/baseline_models/a2c/train_defender.py
@@ -7,7 +7,8 @@ from marlon.baseline_models.multiagent.random_marlon_agent import RandomAgentBui
 ENV_MAX_TIMESTEPS = 1500
 LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ATTACKER_INVALID_ACTION_REWARD = -1
+ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
+ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
 DEFENDER_SAVE_PATH = 'a2c_defender.zip'
@@ -20,7 +21,8 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
+        attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
         defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 

--- a/marlon/baseline_models/a2c/train_marl.py
+++ b/marlon/baseline_models/a2c/train_marl.py
@@ -23,8 +23,8 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
-        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(

--- a/marlon/baseline_models/a2c/train_marl.py
+++ b/marlon/baseline_models/a2c/train_marl.py
@@ -6,7 +6,8 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 1500
 LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ATTACKER_INVALID_ACTION_REWARD = -1
+ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
+ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'a2c_marl_attacker.zip'
@@ -23,7 +24,8 @@ def train(evaluate_after=False):
             alg_type=A2C,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
+        attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
         defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 

--- a/marlon/baseline_models/multiagent/evaluation_stats.py
+++ b/marlon/baseline_models/multiagent/evaluation_stats.py
@@ -1,0 +1,97 @@
+
+from typing import List, Optional
+import logging
+
+import numpy as np
+
+
+class EvalutionStats:
+    '''
+    Represents the results from an evaluation.
+    Compiles some additional statistics for ease of use.
+    '''
+    def __init__(self,
+        episode_steps: List[float],
+        attacker_rewards: List[float],
+        attacker_valid_actions: List[float],
+        attacker_invalid_actions: List[float],
+        defender_rewards: Optional[List[float]],
+        defender_valid_actions: Optional[List[float]],
+        defender_invalid_actions: Optional[List[float]]) -> None:
+
+        self.episode_steps = np.array(episode_steps)
+
+        self.mean_length = np.mean(self.episode_steps)
+        self.std_length = np.std(self.episode_steps)
+
+        self.attacker_rewards = np.array(attacker_rewards)
+        self.attacker_valid_actions = np.array(attacker_valid_actions)
+        self.attacker_invalid_actions = np.array(attacker_invalid_actions)
+
+        self.mean_attacker_reward = np.mean(self.attacker_rewards)
+        self.std_attacker_reward = np.std(self.attacker_rewards)
+
+        self.mean_attacker_valid = np.mean(self.attacker_valid_actions)
+        self.std_attacker_valid = np.std(self.attacker_valid_actions)
+        self.mean_attacker_invalid = np.mean(self.attacker_invalid_actions)
+        self.std_attacker_invalid = np.std(self.attacker_invalid_actions)
+
+        if defender_rewards is not None and len(defender_rewards) > 0:
+            self.defender_rewards = np.array(defender_rewards)
+            self.defender_valid_actions = np.array(defender_valid_actions)
+            self.defender_invalid_actions = np.array(defender_invalid_actions)
+
+            self.mean_defender_reward = np.mean(self.defender_rewards)
+            self.std_defender_reward = np.std(self.defender_rewards)
+
+            self.mean_defender_valid = np.mean(self.defender_valid_actions)
+            self.std_defender_valid = np.std(self.defender_valid_actions)
+            self.mean_defender_invalid = np.mean(self.defender_invalid_actions)
+            self.std_defender_invalid = np.std(self.defender_invalid_actions)
+        else:
+            self.defender_rewards = None
+            self.defender_valid_actions = None
+            self.defender_invalid_actions = None
+
+            self.mean_defender_reward = None
+            self.std_defender_reward = None
+
+            self.mean_defender_valid = None
+            self.std_defender_valid = None
+            self.mean_defender_invalid = None
+            self.std_defender_invalid = None
+
+    def log_results(self, logger: logging.Logger) -> None:
+        logger.info('-------------------------')
+        logger.info('|  Evaluation Results  |')
+        logger.info('-------------------------')
+        logger.info('| Episode length:       |')
+        logger.info('|   mean: %.2f', self.mean_length)
+        logger.info('|   std_dev: %.2f', self.std_length)
+        logger.info('-------------------------')
+        logger.info('| Attacker:             |')
+        logger.info('|   mean:    %.2f', self.mean_attacker_reward)
+        logger.info('|   std_dev: %.2f', self.std_attacker_reward)
+        logger.info('|                       |')
+        logger.info('|   Valid Actions:      |')
+        logger.info('|      mean: %.2f', self.mean_attacker_valid)
+        logger.info('|      std_dev: %.2f', self.std_attacker_valid)
+        logger.info('|                       |')
+        logger.info('|   Invalid Actions:    |')
+        logger.info('|      mean: %.2f', self.mean_attacker_invalid)
+        logger.info('|      std_dev: %.2f', self.std_attacker_invalid)
+        logger.info('-------------------------')
+
+        if self.defender_rewards is not None:
+            logger.info('| Defender:             |')
+            logger.info('|   mean:    %.2f', self.mean_defender_reward)
+            logger.info('|   std_dev: %.2f', self.std_defender_reward)
+            logger.info('|                       |')
+            logger.info('|   Valid Actions:      |')
+            logger.info('|      mean: %.2f', self.mean_defender_valid)
+            logger.info('|      std_dev: %.2f', self.std_defender_valid)
+            logger.info('|                       |')
+            logger.info('|   Invalid Actions:    |')
+            logger.info('|      mean: %.2f', self.mean_defender_invalid)
+            logger.info('|      std_dev: %.2f', self.std_defender_invalid)
+            logger.info('-------------------------')

--- a/marlon/baseline_models/ppo/eval.py
+++ b/marlon/baseline_models/ppo/eval.py
@@ -12,7 +12,7 @@ def evaluate():
             alg_type=PPO,
             file_path=ATTACKER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/ppo/eval_defender.py
+++ b/marlon/baseline_models/ppo/eval_defender.py
@@ -14,7 +14,7 @@ def evaluate():
             alg_type=PPO,
             file_path=DEFENDER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/ppo/eval_marl.py
+++ b/marlon/baseline_models/ppo/eval_marl.py
@@ -17,8 +17,8 @@ def evaluate():
             alg_type=PPO,
             file_path=DEFENDER_SAVE_PATH
         ),
-        attacker_invalid_action_reward=0,
-        defender_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0,
+        defender_invalid_action_reward_modifier=0
     )
 
     universe.evaluate(

--- a/marlon/baseline_models/ppo/train.py
+++ b/marlon/baseline_models/ppo/train.py
@@ -17,7 +17,7 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD
     )
 
     universe.learn(

--- a/marlon/baseline_models/ppo/train.py
+++ b/marlon/baseline_models/ppo/train.py
@@ -6,7 +6,8 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 1500
 LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ATTACKER_INVALID_ACTION_REWARD = -1
+ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
+ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'ppo.zip'
 
@@ -17,7 +18,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
+        attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
     )
 
     universe.learn(

--- a/marlon/baseline_models/ppo/train_defender.py
+++ b/marlon/baseline_models/ppo/train_defender.py
@@ -20,8 +20,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
-        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(

--- a/marlon/baseline_models/ppo/train_marl.py
+++ b/marlon/baseline_models/ppo/train_marl.py
@@ -6,7 +6,8 @@ from marlon.baseline_models.multiagent.multiagent_universe import MultiAgentUniv
 ENV_MAX_TIMESTEPS = 1500
 LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
-ATTACKER_INVALID_ACTION_REWARD = -1
+ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
+ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'ppo_marl_attacker.zip'
@@ -23,7 +24,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
+        attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
         defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 

--- a/marlon/baseline_models/ppo/train_marl.py
+++ b/marlon/baseline_models/ppo/train_marl.py
@@ -23,8 +23,8 @@ def train(evaluate_after=False):
             alg_type=PPO,
             policy='MultiInputPolicy'
         ),
-        attacker_invalid_action_reward=ATTACKER_INVALID_ACTION_REWARD,
-        defender_invalid_action_reward=DEFENDER_INVALID_ACTION_REWARD
+        attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
     )
 
     universe.learn(

--- a/marlon/simulate.py
+++ b/marlon/simulate.py
@@ -21,8 +21,8 @@ def simulate(timesteps, attacker_option, defender_option, attacker_file, defende
     universe = MultiAgentUniverse.build(
         attacker_builder=attacker_builder,
         defender_builder=defender_builder,
-        attacker_invalid_action_reward=0,
-        defender_invalid_action_reward=0
+        attacker_invalid_action_reward_modifier=0,
+        defender_invalid_action_reward_modifier=0
     )
 
     _, _, simulation = marl_algorithm.run_episode(

--- a/testbed.py
+++ b/testbed.py
@@ -28,16 +28,13 @@ def main():
     }
 
     universe = MultiAgentUniverse.build(
-        attacker_builder=attackers['ppo'],
-        attacker_invalid_action_reward=0,
-        defender_builder=BaselineAgentBuilder(
-            PPO,
-            'MultiInputPolicy'
-        ),
-        defender_invalid_action_reward=0,
+        attacker_builder=attackers['random'],
+        attacker_invalid_action_reward_modifier=0,
+        defender_builder=defenders['none'],
+        defender_invalid_action_reward_modifier=0,
     )
 
-    universe.learn(5000, 5)
+    universe.evaluate(5)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Automatically create CSV files containing evaluation results from every agent combination!

Example CSV:
[eval_results.csv](https://github.com/James-LG/MARLon/files/8419524/eval_results.csv)

ALSO: Adds the reward multiplier from my A2C invalid reward penalty scenario. Which would be `modifier=0`, `multiplier=0`. Our previous approach would be `modifier=-1`,` multiplier=1`.