### PR TITLE
fix: EvaluationStats only stores mean and std dev to save RAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pkl
 *.zip
 *.csv
+*.xlsx

--- a/evaluate.py
+++ b/evaluate.py
@@ -54,7 +54,6 @@ def main():
         'deepq': QCompatibilityAgentBuilder('deepq.pkl'),
         'ppo': LoadFileBaselineAgentBuilder(PPO, 'ppo.zip'),
         'ppo_marl': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_attacker.zip'),
-        'ppo_marl_no_reset': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_no_reset.zip'),
         'a2c': LoadFileBaselineAgentBuilder(A2C, 'a2c.zip'),
         'a2c_marl': LoadFileBaselineAgentBuilder(A2C, 'a2c_marl_attacker.zip'),
     }
@@ -64,7 +63,6 @@ def main():
         'random': RandomAgentBuilder(),
         'ppo': LoadFileBaselineAgentBuilder(PPO, 'ppo_defender.zip'),
         'ppo_marl': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_defender.zip'),
-        'ppo_marl_no_reset': LoadFileBaselineAgentBuilder(PPO, 'ppo_marl_defender_no_reset.zip'),
         'a2c': LoadFileBaselineAgentBuilder(A2C, 'a2c_defender.zip'),
         'a2c_marl': LoadFileBaselineAgentBuilder(A2C, 'a2c_marl_defender.zip'),
     }
@@ -83,8 +81,8 @@ def main():
                 defender_invalid_action_reward_modifier=0,
             )
 
-            results[attacker_name][defender_name] = universe.evaluate(5)
-    
+            results[attacker_name][defender_name] = universe.evaluate(20)
+
     write_csv(results)
 
 if __name__ == "__main__":

--- a/marlon/baseline_models/a2c/train_defender.py
+++ b/marlon/baseline_models/a2c/train_defender.py
@@ -10,6 +10,7 @@ LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS in
 ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
 ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
+DEFENDER_RESET_ON_CONSTRAINT_BROKEN = False
 EVALUATE_EPISODES = 5
 DEFENDER_SAVE_PATH = 'a2c_defender.zip'
 
@@ -23,7 +24,8 @@ def train(evaluate_after=False):
         ),
         attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
         attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
-        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD,
+        defender_reset_on_constraint_broken=DEFENDER_RESET_ON_CONSTRAINT_BROKEN,
     )
 
     universe.learn(

--- a/marlon/baseline_models/a2c/train_marl.py
+++ b/marlon/baseline_models/a2c/train_marl.py
@@ -9,6 +9,7 @@ LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS in
 ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
 ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
+DEFENDER_RESET_ON_CONSTRAINT_BROKEN = False
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'a2c_marl_attacker.zip'
 DEFENDER_SAVE_PATH = 'a2c_marl_defender.zip'
@@ -26,7 +27,8 @@ def train(evaluate_after=False):
         ),
         attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
         attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
-        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD,
+        defender_reset_on_constraint_broken=DEFENDER_RESET_ON_CONSTRAINT_BROKEN,
     )
 
     universe.learn(

--- a/marlon/baseline_models/multiagent/evaluation_stats.py
+++ b/marlon/baseline_models/multiagent/evaluation_stats.py
@@ -24,35 +24,31 @@ class EvalutionStats:
         self.mean_length = np.mean(self.episode_steps)
         self.std_length = np.std(self.episode_steps)
 
-        self.attacker_rewards = np.array(attacker_rewards)
-        self.attacker_valid_actions = np.array(attacker_valid_actions)
-        self.attacker_invalid_actions = np.array(attacker_invalid_actions)
+        attacker_rewards = np.array(attacker_rewards)
+        attacker_valid_actions = np.array(attacker_valid_actions)
+        attacker_invalid_actions = np.array(attacker_invalid_actions)
 
-        self.mean_attacker_reward = np.mean(self.attacker_rewards)
-        self.std_attacker_reward = np.std(self.attacker_rewards)
+        self.mean_attacker_reward = np.mean(attacker_rewards)
+        self.std_attacker_reward = np.std(attacker_rewards)
 
-        self.mean_attacker_valid = np.mean(self.attacker_valid_actions)
-        self.std_attacker_valid = np.std(self.attacker_valid_actions)
-        self.mean_attacker_invalid = np.mean(self.attacker_invalid_actions)
-        self.std_attacker_invalid = np.std(self.attacker_invalid_actions)
+        self.mean_attacker_valid = np.mean(attacker_valid_actions)
+        self.std_attacker_valid = np.std(attacker_valid_actions)
+        self.mean_attacker_invalid = np.mean(attacker_invalid_actions)
+        self.std_attacker_invalid = np.std(attacker_invalid_actions)
 
         if defender_rewards is not None and len(defender_rewards) > 0:
-            self.defender_rewards = np.array(defender_rewards)
-            self.defender_valid_actions = np.array(defender_valid_actions)
-            self.defender_invalid_actions = np.array(defender_invalid_actions)
+            defender_rewards = np.array(defender_rewards)
+            defender_valid_actions = np.array(defender_valid_actions)
+            defender_invalid_actions = np.array(defender_invalid_actions)
 
-            self.mean_defender_reward = np.mean(self.defender_rewards)
-            self.std_defender_reward = np.std(self.defender_rewards)
+            self.mean_defender_reward = np.mean(defender_rewards)
+            self.std_defender_reward = np.std(defender_rewards)
 
-            self.mean_defender_valid = np.mean(self.defender_valid_actions)
-            self.std_defender_valid = np.std(self.defender_valid_actions)
-            self.mean_defender_invalid = np.mean(self.defender_invalid_actions)
-            self.std_defender_invalid = np.std(self.defender_invalid_actions)
+            self.mean_defender_valid = np.mean(defender_valid_actions)
+            self.std_defender_valid = np.std(defender_valid_actions)
+            self.mean_defender_invalid = np.mean(defender_invalid_actions)
+            self.std_defender_invalid = np.std(defender_invalid_actions)
         else:
-            self.defender_rewards = None
-            self.defender_valid_actions = None
-            self.defender_invalid_actions = None
-
             self.mean_defender_reward = None
             self.std_defender_reward = None
 
@@ -82,7 +78,7 @@ class EvalutionStats:
         logger.info('|      std_dev: %.2f', self.std_attacker_invalid)
         logger.info('-------------------------')
 
-        if self.defender_rewards is not None:
+        if self.mean_defender_reward is not None:
             logger.info('| Defender:             |')
             logger.info('|   mean:    %.2f', self.mean_defender_reward)
             logger.info('|   std_dev: %.2f', self.std_defender_reward)

--- a/marlon/baseline_models/ppo/train_defender.py
+++ b/marlon/baseline_models/ppo/train_defender.py
@@ -9,6 +9,7 @@ LEARN_TIMESTEPS = 300_000
 LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS instead.
 ATTACKER_INVALID_ACTION_REWARD = -1
 DEFENDER_INVALID_ACTION_REWARD = -1
+DEFENDER_RESET_ON_CONSTRAINT_BROKEN = False
 EVALUATE_EPISODES = 5
 DEFENDER_SAVE_PATH = 'ppo_defender.zip'
 
@@ -21,7 +22,8 @@ def train(evaluate_after=False):
             policy='MultiInputPolicy'
         ),
         attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD,
-        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD,
+        defender_reset_on_constraint_broken=DEFENDER_RESET_ON_CONSTRAINT_BROKEN,
     )
 
     universe.learn(

--- a/marlon/baseline_models/ppo/train_marl.py
+++ b/marlon/baseline_models/ppo/train_marl.py
@@ -9,6 +9,7 @@ LEARN_EPISODES = 10000 # Set this to a large value to stop at LEARN_TIMESTEPS in
 ATTACKER_INVALID_ACTION_REWARD_MODIFIER = 0
 ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER = 0
 DEFENDER_INVALID_ACTION_REWARD = -1
+DEFENDER_RESET_ON_CONSTRAINT_BROKEN = False
 EVALUATE_EPISODES = 5
 ATTACKER_SAVE_PATH = 'ppo_marl_attacker.zip'
 DEFENDER_SAVE_PATH = 'ppo_marl_defender.zip'
@@ -26,7 +27,8 @@ def train(evaluate_after=False):
         ),
         attacker_invalid_action_reward_modifier=ATTACKER_INVALID_ACTION_REWARD_MODIFIER,
         attacker_invalid_action_reward_multiplier=ATTACKER_INVALID_ACTION_REWARD_MULTIPLIER,
-        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD
+        defender_invalid_action_reward_modifier=DEFENDER_INVALID_ACTION_REWARD,
+        defender_reset_on_constraint_broken=DEFENDER_RESET_ON_CONSTRAINT_BROKEN,
     )
 
     universe.learn(

--- a/marlon/simulate.py
+++ b/marlon/simulate.py
@@ -41,8 +41,7 @@ def create_builder(option, file):
         builder = RandomAgentBuilder()
     elif option == 'Load':
         if 'pkl' in file:
-            learner = torch.load(file)
-            builder = QCompatibilityAgentBuilder(learner=learner)
+            builder = QCompatibilityAgentBuilder(file_path=file)
         else:
             if 'ppo' in file:
                 alg_type = PPO


### PR DESCRIPTION
Attacker and defender rewards and [in]valid actions were saved in EvaluationStats. Over many episodes this accumulates to far greater than 32 GB of RAM. Instead perform the mean and standard deviation calculations and dump the results.

Also fix small bug in simulate.py